### PR TITLE
Update build tools and add Arch info to startup message

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -1,6 +1,8 @@
 ifeq ($(CC), emcc)
 NOURING := 1
 NOOPENSSL := 1
+NOMIMALLOC := 1
+NOJEMALLOC := 1
 CFLAGS := -Wall -Wextra -Werror -O3 $(CFLAGS)
 LDFLAGS := -sASSERTIONS=1 -sINITIAL_MEMORY=64MB \
     -sEXPORTED_FUNCTIONS='["_malloc","_free","_exec_command","_add_time","_main"]' \
@@ -86,11 +88,14 @@ CFLAGS += -I../deps/openssl/include
 endif
 endif
 
+MUSL := $(shell ldd --version 2>&1 | head -n1 | grep -o musl || true)
 ifndef NOSTATIC
-LIBC := $(shell ldd --version 2>&1 | head -n1 | grep -o musl || true)
-ifeq ($(LIBC),musl)
+ifeq ($(MUSL),musl)
 CFLAGS += -static
 endif
+endif
+ifeq ($(MUSL),musl)
+CFLAGS += -D__MUSL__
 endif
 
 all: ../pogocache

--- a/src/main.c
+++ b/src/main.c
@@ -724,9 +724,10 @@ int main(int argc, char *argv[]) {
     }
 
     // Print the program details
-    printf("* Pogocache (pid: %d, arch: %s%s, version: %s, git: %s)\n",
-        getpid(), sys_arch(), sizeof(uintptr_t)==4?", mode: 32-bit":"", version,
-        githash);
+    printf("* Pogocache (pid: %d, version: %s, git: %s)\n", getpid(), 
+        version, githash);
+    printf("* Arch (arch: %s%s, libc: %s, os: %s)\n", sys_arch(), 
+        sizeof(uintptr_t)==4?", mode: 32-bit":"", sys_libc(), sys_os());
     char buf0[64], buf1[64];
     char buf2[64];
     if (memlimit < SIZE_MAX) {

--- a/src/monitor.c
+++ b/src/monitor.c
@@ -1,3 +1,14 @@
+// https://github.com/tidwall/pogocache
+//
+// Copyright 2025 Polypoint Labs, LLC. All rights reserved.
+// This file is part of the Pogocache project.
+// Use of this source code is governed by the AGPL that can be found in
+// the LICENSE file.
+//
+// For alternative licensing options or general questions, please contact
+// us at licensing@polypointlabs.com.
+//
+// Unit monitor.c provides functions for the MONITOR command.
 #include <stdatomic.h>
 #include <pthread.h>
 #include "monitor.h"

--- a/src/monitor.h
+++ b/src/monitor.h
@@ -1,3 +1,12 @@
+// https://github.com/tidwall/pogocache
+//
+// Copyright 2025 Polypoint Labs, LLC. All rights reserved.
+// This file is part of the Pogocache project.
+// Use of this source code is governed by the AGPL that can be found in
+// the LICENSE file.
+//
+// For alternative licensing options or general questions, please contact
+// us at licensing@polypointlabs.com.
 #ifndef MONITOR_H
 #define MONITOR_H
 

--- a/src/sys.h
+++ b/src/sys.h
@@ -19,6 +19,7 @@ uint64_t sys_seed(void);
 int64_t sys_now(void);
 int64_t sys_unixnow(void);
 const char *sys_arch(void);
+const char *sys_libc(void);
 void sys_genuseid(char useid[16]);
 
 struct sys_meminfo {
@@ -28,5 +29,6 @@ struct sys_meminfo {
 
 void sys_getmeminfo(struct sys_meminfo *info); 
 uint64_t sys_threadid(void);
+const char *sys_os(void);
 
 #endif

--- a/tools/Dockerfile
+++ b/tools/Dockerfile
@@ -1,4 +1,9 @@
-FROM scratch
-COPY pogocache /pogocache
+FROM alpine:3.22
+
+COPY entrypoint.sh /usr/local/bin/
+RUN chmod +x /usr/local/bin/entrypoint.sh
+ENTRYPOINT ["entrypoint.sh"]
+
+COPY pogocache /usr/local/bin/
 EXPOSE 9401
-ENTRYPOINT ["/pogocache"]
+CMD ["pogocache"]

--- a/tools/build/run.sh
+++ b/tools/build/run.sh
@@ -4,16 +4,16 @@ set -e
 cd $(dirname "${BASH_SOURCE[0]}")
 wd=$(pwd)
 
-if [[ "$1" == "linux-aarch64" ]]; then
+if [[ "$1" == "linux-arm64-musl" ]]; then
     platform="linux/arm64"
     libc="musl"
 elif [[ "$1" == "linux-arm64" ]]; then
     platform="linux/arm64"
     libc="glibc"
-elif [[ "$1" == "linux-amd64" ]]; then
+elif [[ "$1" == "linux-amd64-musl" ]]; then
     platform="linux/amd64"
     libc="musl"
-elif [[ "$1" == "linux-x86_64" ]]; then
+elif [[ "$1" == "linux-amd64" ]]; then
     platform="linux/amd64"
     libc="glibc"
 elif [[ "$1" == "apple-arm64" ]]; then
@@ -23,11 +23,11 @@ else
     echo "Usage: $0 <arch>"
     echo ""
     echo "Valid architectures:"
-    echo "   linux-aarch64 -- musl"
-    echo "   linux-amd64   -- musl"
-    echo "   linux-arm64   -- glibc" 
-    echo "   linux-x86_64  -- glibc"
-    echo "   apple-arm64   -- Apple Silicon"
+    echo "   linux-arm64-musl -- musl"
+    echo "   linux-amd64-musl -- musl"
+    echo "   linux-arm64      -- glibc" 
+    echo "   linux-amd64      -- glibc"
+    echo "   apple-arm64      -- Apple Silicon"
     echo ""
     exit 1
 fi
@@ -58,7 +58,7 @@ make gitinfo
 tar -czf repo.tar.gz deps/ src/
 cd $wd
 mv ../../repo.tar.gz .
-reposha=$(tar -O -xf repo.tar.gz | sha1sum --quiet)
+reposha=$(tar -O -xf repo.tar.gz | sha1sum | awk '{print $1;}')
 
 build=1
 if [[ -f "../../packages/$name.tar.gz" ]]; then

--- a/tools/entrypoint.sh
+++ b/tools/entrypoint.sh
@@ -1,0 +1,8 @@
+#!/bin/sh
+set -e
+
+if [ "${1#-}" != "$1" ] || [ "${1%.conf}" != "$1" ]; then
+	set -- pogocache "$@"
+fi
+
+exec "$@" $POGOCACHE_EXTRA_FLAGS

--- a/tools/package.sh
+++ b/tools/package.sh
@@ -3,9 +3,9 @@
 set -e
 cd $(dirname "${BASH_SOURCE[0]}")
 
-build/run.sh linux-aarch64
+build/run.sh linux-arm64-musl
 build/run.sh linux-arm64
-build/run.sh linux-x86_64
+build/run.sh linux-amd64-musl
 build/run.sh linux-amd64
 if [[ "$(uname)" == "Darwin" && "$(uname -m)" == "arm64" ]]; then
     build/run.sh apple-arm64


### PR DESCRIPTION
This commit updates the build tooling to provide more clarity around architecture and versions, making things easier for diagnostics and platform choice.

- Include Arch section to startup message, add OS tag
- Use arm64/amd64 tags instead of aarch64/x86_64
- Use alpine as the base image for containers
- Provide clearer release names. Static builds use the musl libc and have the '-musl' suffix, otherwise glibc.