### PR TITLE
Implement the SELECT command

### DIFF
--- a/src/cmds.c
+++ b/src/cmds.c
@@ -585,7 +585,18 @@ static void cmdKEYS(struct conn *conn, struct args *args) {
 }
 
 static void cmdSELECT(struct conn *conn, struct args *args) {
-    (void)args;
+    if (args->len != 2) {
+        conn_write_error(conn, ERR_WRONG_NUM_ARGS);
+        return;
+    }
+    int64_t db = 0;
+    bool ok = parse_i64(args->bufs[1].data, args->bufs[1].len, &db);
+    const bool out_of_range = (ok && db > 0);
+    ok = (ok && !out_of_range);
+    if (!ok) {
+        conn_write_error(conn, (out_of_range) ? ERR_INDEX_OUT_OF_RANGE : ERR_INVALID_INTEGER);
+        return;
+    }
     if (conn_proto(conn) == PROTO_RESP) {
         conn_write_string(conn, "OK");
     }

--- a/src/conn.h
+++ b/src/conn.h
@@ -20,6 +20,7 @@
 
 #define ERR_WRONG_NUM_ARGS      "ERR wrong number of arguments"
 #define ERR_SYNTAX_ERROR        "ERR syntax error"
+#define ERR_INDEX_OUT_OF_RANGE	"ERR index is out of range"
 #define ERR_INVALID_INTEGER     "ERR value is not an integer or out of range"
 #define ERR_OUT_OF_MEMORY       "ERR out of memory"
 #define CLIENT_ERROR_BAD_FORMAT "CLIENT_ERROR bad command line format"


### PR DESCRIPTION
Rationale: Although we do not support multiple databases, given the constraints of pogocache it is better to pretend we do than to break existing code that tries to do things like `SELECT 0` rather than just use the available database.

I'm not 100% sure about this so feel free to close if you don't think it's a good idea.