### PR TITLE
Make dependencies first

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -105,7 +105,9 @@ OBJS += memcache.o postgres.o tls.o save.o parse.o lz4.o
 OBJS += net.o xmalloc.o main.o pogocache.o resp.o http.o 
 OBJS += hashmap.o monitor.o
 
-../pogocache: $(DEPS) $(OBJS)
+$(OBJS): $(DEPS)
+
+../pogocache: $(OBJS)
 	$(CC) $(CFLAGS) -o ../pogocache$(OUTEXT) $(LDFLAGS) $(OBJS) $(CLIBS)
 
 clean:


### PR DESCRIPTION
Make dependencies first to prevent make fail when -j flag is set.